### PR TITLE
Change how mvp-based viewgroup implements lifecycle

### DIFF
--- a/arctor-base/src/main/java/com/alapshin/arctor/delegate/ViewGroupMvpDelegate.java
+++ b/arctor-base/src/main/java/com/alapshin/arctor/delegate/ViewGroupMvpDelegate.java
@@ -24,6 +24,11 @@ public interface ViewGroupMvpDelegate<V extends MvpView, P extends Presenter<V>>
     void onDetachedFromWindow();
 
     /**
+     * Call from {@link ViewGroup#onWindowVisibilityChanged(int)}
+     */
+    void onWindowVisibilityChanges(int visibility);
+
+    /**
      * Call from {@link ViewGroup#onRestoreInstanceState(Parcelable)}
      * @param state The parcelable state.
      */

--- a/arctor-base/src/main/java/com/alapshin/arctor/delegate/ViewGroupMvpDelegateImpl.java
+++ b/arctor-base/src/main/java/com/alapshin/arctor/delegate/ViewGroupMvpDelegateImpl.java
@@ -1,6 +1,7 @@
 package com.alapshin.arctor.delegate;
 
 import android.os.Parcelable;
+import android.view.View;
 
 import com.alapshin.arctor.presenter.Presenter;
 import com.alapshin.arctor.view.MvpView;
@@ -18,16 +19,23 @@ public class ViewGroupMvpDelegateImpl<V extends MvpView, P extends Presenter<V>>
     public void onAttachedToWindow() {
         callback.getPresenter().onCreate(null);
         callback.getPresenter().attachView(callback.getMvpView());
-        callback.getPresenter().onStart();
-        callback.getPresenter().onResume();
     }
 
     @Override
     public void onDetachedFromWindow() {
         callback.getPresenter().detachView();
-        callback.getPresenter().onPause();
-        callback.getPresenter().onStop();
         callback.getPresenter().onDestroy();
+    }
+
+    @Override
+    public void onWindowVisibilityChanges(int visibility) {
+        if (visibility == View.VISIBLE) {
+            callback.getPresenter().onStart();
+            callback.getPresenter().onResume();
+        } else if (visibility == View.GONE) {
+            callback.getPresenter().onPause();
+            callback.getPresenter().onStop();
+        }
     }
 
     @Override

--- a/arctor-base/src/main/java/com/alapshin/arctor/view/MvpFrameLayout.java
+++ b/arctor-base/src/main/java/com/alapshin/arctor/view/MvpFrameLayout.java
@@ -72,4 +72,10 @@ public abstract class MvpFrameLayout<V extends MvpView, P extends Presenter<V>>
         super.onDetachedFromWindow();
         mvpDelegate.onDetachedFromWindow();
     }
+
+    @Override
+    protected void onWindowVisibilityChanged(int visibility) {
+        super.onWindowVisibilityChanged(visibility);
+        mvpDelegate.onWindowVisibilityChanges(visibility);
+    }
 }


### PR DESCRIPTION
Co-opt onWindowVisibilityChanged method to indicate onResume/onPause
and onStart/onStop lifecycle events in mvp-based viewgroup.